### PR TITLE
[1주차 기본/심화 과제] 웨비들의 냠냠 🍰 창업🏠

### DIFF
--- a/week1/assign3/index.html
+++ b/week1/assign3/index.html
@@ -13,14 +13,12 @@
   </head>
   <body>
     <header>
-      <main id="header__main">
-        <h1>~은서네 샤브샤브~</h1>
-        <button id="header__button"><i class="fa-solid fa-bars"></i></button>
-      </main>
+      <h1>마라탕 드실분?</h1>
+      <button id="header__button"><i class="fa-solid fa-bars"></i></button>
       <section id="header__menu">
-        <h2>메뉴</h2>
-        <h3>새 상품 추가</h3>
-        <h3>찜 목록</h3>
+        <h1>메뉴</h1>
+        <h2>새 상품 추가</h2>
+        <h2>찜 목록</h2>
       </section>
     </header>
     <main>

--- a/week1/assign3/index.html
+++ b/week1/assign3/index.html
@@ -39,10 +39,6 @@
           </li>
           <li>
             <input type="checkbox" />
-            <h3>두부</h3>
-          </li>
-          <li>
-            <input type="checkbox" />
             <h3>기타</h3>
           </li>
         </ul>

--- a/week1/assign3/index.html
+++ b/week1/assign3/index.html
@@ -46,8 +46,12 @@
       <section id="cards">
         <ul>
           <li class="cards__card">
+            </small>
             <h3>청경채</h3>
-            <small>#푸릇푸릇 #신선</small>
+            <div class="cards__card__tags">
+              <small>푸릇푸릇</small>
+              <small>신선</small>
+            </div>
             <img
               alt="청경채"
               src="https://img-cf.kurly.com/shop/data/goods/1619680685239l0.jpg"
@@ -56,7 +60,10 @@
           </li>
           <li class="cards__card">
             <h3>배추</h3>
-            <small>#필수템 #무한흡입</small>
+            <div class="cards__card__tags">
+              <small>필수템</small>
+              <small>무한 흡입</small>
+            </div>
             <img
               alt="배추"
               src="https://img-cf.kurly.com/shop/data/goodsview/20200717/gv00000107986_1.jpg"
@@ -65,7 +72,10 @@
           </li>
           <li class="cards__card">
             <h3>연근</h3>
-            <small>#아삭아삭 #별미</small>
+            <div class="cards__card__tags">
+              <small>아삭아삭</small>
+              <small>별미</small>
+            </div>
             <img
               alt="연근"
               src="https://img-cf.kurly.com/shop/data/goodsview/20220216/gv20000280932_1.jpg"
@@ -74,7 +84,10 @@
           </li>
           <li class="cards__card">
             <h3>흰목이버섯</h3>
-            <small>#필수템 #포들포들</small>
+            <div class="cards__card__tags">
+              <small>필수템</small>
+              <small>포들포들</small>
+            </div>
             <img
               alt="흰목이버섯"
               src="https://img-cf.kurly.com/shop/data/goodsview/20200515/gv20000095604_1.jpg"
@@ -83,7 +96,10 @@
           </li>
           <li class="cards__card">
             <h3>새송이버섯</h3>
-            <small>#무난템 #말랑말랑</small>
+            <div class="cards__card__tags">
+              <small>무난템</small>
+              <small>말랑말랑</small>
+            </div>
             <img
               alt="새송이버섯"
               src="https://img-cf.kurly.com/shop/data/goodsview/20200306/gv20000084569_1.jpg"
@@ -92,7 +108,10 @@
           </li>
           <li class="cards__card">
             <h3>면두부</h3>
-            <small>#다이어트 #고소해</small>
+            <div class="cards__card__tags">
+              <small>다이어트</small>
+              <small>고소해</small>
+            </div>
             <img
               alt="면두부"
               src="https://img-cf.kurly.com/shop/data/goodsview/20211110/gv30000241778_1.jpg"
@@ -101,7 +120,10 @@
           </li>
           <li class="cards__card">
             <h3>유부</h3>
-            <small>#촉촉 #별미</small>
+            <div class="cards__card__tags">
+              <small>촉촉</small>
+              <small>국물쫙</small>
+            </div>
             <img
               alt="유부"
               src="https://img-cf.kurly.com/shop/data/goodsview/20190129/gv40000042637_1.jpg"
@@ -110,7 +132,10 @@
           </li>
           <li class="cards__card">
             <h3>푸주</h3>
-            <small>#dobo #fuzu</small>
+            <div class="cards__card__tags">
+              <small>tofu</small>
+              <small>fuzu</small>
+            </div>
             <img
               alt="푸주"
               src="https://product-image.kurly.com/product/image/c5c5f9e4-5ee3-4e2b-b36b-1aa5301d97d6.jpg"
@@ -119,7 +144,10 @@
           </li>
           <li class="cards__card">
             <h3>치즈떡</h3>
-            <small>#쫄깃쫄깃 #말랑말랑</small>
+            <div class="cards__card__tags">
+              <small>#쫄깃쫄깃</small>
+              <small>#말랑말랑</small>
+            </div>
             <img
               alt="치즈떡"
               src="https://img-cf.kurly.com/shop/data/goods/1640659336778l0.jpg"
@@ -128,7 +156,10 @@
           </li>
           <li class="cards__card">
             <h3>새우</h3>
-            <small>#무조건 #새우탕ㄱㄱ</small>
+            <div class="cards__card__tags">
+              <small>무조건</small>
+              <small>새우탕ㄱㄱ</small>
+            </div>
             <img
               alt="새우"
               src="https://img-cf.kurly.com/shop/data/goodsview/20211227/gv20000262359_1.jpg"

--- a/week1/assign3/index.html
+++ b/week1/assign3/index.html
@@ -13,9 +13,11 @@
   </head>
   <body>
     <header>
-      <h1>~은서네 샤브샤브~</h1>
-      <button><i class="fa-solid fa-bars"></i></button>
-      <section>
+      <main id="header__main">
+        <h1>~은서네 샤브샤브~</h1>
+        <button id="header__button"><i class="fa-solid fa-bars"></i></button>
+      </main>
+      <section id="header__menu">
         <h2>메뉴</h2>
         <h3>새 상품 추가</h3>
         <h3>찜 목록</h3>

--- a/week1/assign3/index.html
+++ b/week1/assign3/index.html
@@ -9,6 +9,7 @@
       src="https://kit.fontawesome.com/6fbcf91afd.js"
       crossorigin="anonymous"
     ></script>
+    <link rel="stylesheet" href="style.css" />
   </head>
   <body>
     <header>

--- a/week1/assign3/index.html
+++ b/week1/assign3/index.html
@@ -47,9 +47,9 @@
           </li>
         </ul>
       </nav>
-      <section>
+      <section id="cards">
         <ul>
-          <li>
+          <li class="cards__card">
             <h3>청경채</h3>
             <small>#푸릇푸릇 #신선</small>
             <img
@@ -57,7 +57,7 @@
             />
             <i class="fa-regular fa-heart"></i>
           </li>
-          <li>
+          <li class="cards__card">
             <h3>배추</h3>
             <small>#필수템 #무한흡입</small>
             <img
@@ -65,7 +65,7 @@
             />
             <i class="fa-regular fa-heart"></i>
           </li>
-          <li>
+          <li class="cards__card">
             <h3>연근</h3>
             <small>#아삭아삭 #별미</small>
             <img
@@ -73,7 +73,7 @@
             />
             <i class="fa-regular fa-heart"></i>
           </li>
-          <li>
+          <li class="cards__card">
             <h3>흰목이버섯</h3>
             <small>#필수템 #포들포들</small>
             <img
@@ -81,7 +81,7 @@
             />
             <i class="fa-regular fa-heart"></i>
           </li>
-          <li>
+          <li class="cards__card">
             <h3>새송이버섯</h3>
             <small>#무난템 #말랑말랑</small>
             <img
@@ -89,7 +89,7 @@
             />
             <i class="fa-regular fa-heart"></i>
           </li>
-          <li>
+          <li class="cards__card">
             <h3>면두부</h3>
             <small>#다이어트 #고소해</small>
             <img
@@ -97,7 +97,7 @@
             />
             <i class="fa-regular fa-heart"></i>
           </li>
-          <li>
+          <li class="cards__card">
             <h3>유부</h3>
             <small>#촉촉 #별미</small>
             <img
@@ -105,7 +105,7 @@
             />
             <i class="fa-regular fa-heart"></i>
           </li>
-          <li>
+          <li class="cards__card">
             <h3>푸주</h3>
             <small>#dobo #fuzu</small>
             <img
@@ -113,7 +113,7 @@
             />
             <i class="fa-regular fa-heart"></i>
           </li>
-          <li>
+          <li class="cards__card">
             <h3>치즈떡</h3>
             <small>#쫄깃쫄깃 #말랑말랑</small>
             <img
@@ -121,7 +121,7 @@
             />
             <i class="fa-regular fa-heart"></i>
           </li>
-          <li>
+          <li class="cards__card">
             <h3>새우</h3>
             <small>#무조건 #새우탕ㄱㄱ</small>
             <img

--- a/week1/assign3/index.html
+++ b/week1/assign3/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>은서네 샤브샤브</title>
+    <title>은서네 마라마라탕</title>
     <script
       src="https://kit.fontawesome.com/6fbcf91afd.js"
       crossorigin="anonymous"
@@ -13,7 +13,7 @@
   </head>
   <body>
     <header>
-      <h1>마라탕 드실분?</h1>
+      <h1>은서네 마라마라탕 🥬🍄🍡</h1>
       <button id="header__button"><i class="fa-solid fa-bars"></i></button>
       <section id="header__menu">
         <h1>메뉴</h1>

--- a/week1/assign3/index.html
+++ b/week1/assign3/index.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>은서네 샤브샤브</title>
+    <script
+      src="https://kit.fontawesome.com/6fbcf91afd.js"
+      crossorigin="anonymous"
+    ></script>
+  </head>
+  <body>
+    <header>
+      <h1>~은서네 샤브샤브~</h1>
+      <button><i class="fa-solid fa-bars"></i></button>
+      <section>
+        <h2>메뉴</h2>
+        <h3>새 상품 추가</h3>
+        <h3>찜 목록</h3>
+      </section>
+    </header>
+    <main>
+      <nav>
+        <h2>분류</h2>
+        <ul>
+          <li>
+            <input type="checkbox" />
+            <h3>전체</h3>
+          </li>
+          <li>
+            <input type="checkbox" />
+            <h3>채소</h3>
+          </li>
+          <li>
+            <input type="checkbox" />
+            <h3>버섯</h3>
+          </li>
+          <li>
+            <input type="checkbox" />
+            <h3>두부</h3>
+          </li>
+          <li>
+            <input type="checkbox" />
+            <h3>기타</h3>
+          </li>
+        </ul>
+      </nav>
+      <section>
+        <ul>
+          <li>
+            <h3>청경채</h3>
+            <small>#푸릇푸릇 #신선</small>
+            <img
+              src="https://img-cf.kurly.com/shop/data/goods/1619680685239l0.jpg"
+            />
+            <i class="fa-regular fa-heart"></i>
+          </li>
+          <li>
+            <h3>배추</h3>
+            <small>#필수템 #무한흡입</small>
+            <img
+              src="https://img-cf.kurly.com/shop/data/goodsview/20200717/gv00000107986_1.jpg"
+            />
+            <i class="fa-regular fa-heart"></i>
+          </li>
+          <li>
+            <h3>연근</h3>
+            <small>#아삭아삭 #별미</small>
+            <img
+              src="https://img-cf.kurly.com/shop/data/goodsview/20220216/gv20000280932_1.jpg"
+            />
+            <i class="fa-regular fa-heart"></i>
+          </li>
+          <li>
+            <h3>흰목이버섯</h3>
+            <small>#필수템 #포들포들</small>
+            <img
+              src="https://img-cf.kurly.com/shop/data/goodsview/20200515/gv20000095604_1.jpg"
+            />
+            <i class="fa-regular fa-heart"></i>
+          </li>
+          <li>
+            <h3>새송이버섯</h3>
+            <small>#무난템 #말랑말랑</small>
+            <img
+              src="https://img-cf.kurly.com/shop/data/goodsview/20200306/gv20000084569_1.jpg"
+            />
+            <i class="fa-regular fa-heart"></i>
+          </li>
+          <li>
+            <h3>면두부</h3>
+            <small>#다이어트 #고소해</small>
+            <img
+              src="https://img-cf.kurly.com/shop/data/goodsview/20211110/gv30000241778_1.jpg"
+            />
+            <i class="fa-regular fa-heart"></i>
+          </li>
+          <li>
+            <h3>유부</h3>
+            <small>#촉촉 #별미</small>
+            <img
+              src="https://img-cf.kurly.com/shop/data/goodsview/20190129/gv40000042637_1.jpg"
+            />
+            <i class="fa-regular fa-heart"></i>
+          </li>
+          <li>
+            <h3>푸주</h3>
+            <small>#dobo #fuzu</small>
+            <img
+              src="https://product-image.kurly.com/product/image/c5c5f9e4-5ee3-4e2b-b36b-1aa5301d97d6.jpg"
+            />
+            <i class="fa-regular fa-heart"></i>
+          </li>
+          <li>
+            <h3>치즈떡</h3>
+            <small>#쫄깃쫄깃 #말랑말랑</small>
+            <img
+              src="https://img-cf.kurly.com/shop/data/goods/1640659336778l0.jpg"
+            />
+            <i class="fa-regular fa-heart"></i>
+          </li>
+          <li>
+            <h3>새우</h3>
+            <small>#무조건 #새우탕ㄱㄱ</small>
+            <img
+              src="https://img-cf.kurly.com/shop/data/goodsview/20211227/gv20000262359_1.jpg"
+            />
+            <i class="fa-regular fa-heart"></i>
+          </li>
+        </ul>
+      </section>
+    </main>
+  </body>
+</html>

--- a/week1/assign3/index.html
+++ b/week1/assign3/index.html
@@ -49,6 +49,7 @@
             <h3>청경채</h3>
             <small>#푸릇푸릇 #신선</small>
             <img
+              alt="청경채"
               src="https://img-cf.kurly.com/shop/data/goods/1619680685239l0.jpg"
             />
             <i class="fa-solid fa-heart"></i>
@@ -57,6 +58,7 @@
             <h3>배추</h3>
             <small>#필수템 #무한흡입</small>
             <img
+              alt="배추"
               src="https://img-cf.kurly.com/shop/data/goodsview/20200717/gv00000107986_1.jpg"
             />
             <i class="fa-solid fa-heart"></i>
@@ -65,6 +67,7 @@
             <h3>연근</h3>
             <small>#아삭아삭 #별미</small>
             <img
+              alt="연근"
               src="https://img-cf.kurly.com/shop/data/goodsview/20220216/gv20000280932_1.jpg"
             />
             <i class="fa-solid fa-heart"></i>
@@ -73,6 +76,7 @@
             <h3>흰목이버섯</h3>
             <small>#필수템 #포들포들</small>
             <img
+              alt="흰목이버섯"
               src="https://img-cf.kurly.com/shop/data/goodsview/20200515/gv20000095604_1.jpg"
             />
             <i class="fa-solid fa-heart"></i>
@@ -81,6 +85,7 @@
             <h3>새송이버섯</h3>
             <small>#무난템 #말랑말랑</small>
             <img
+              alt="새송이버섯"
               src="https://img-cf.kurly.com/shop/data/goodsview/20200306/gv20000084569_1.jpg"
             />
             <i class="fa-solid fa-heart"></i>
@@ -89,6 +94,7 @@
             <h3>면두부</h3>
             <small>#다이어트 #고소해</small>
             <img
+              alt="면두부"
               src="https://img-cf.kurly.com/shop/data/goodsview/20211110/gv30000241778_1.jpg"
             />
             <i class="fa-solid fa-heart"></i>
@@ -97,6 +103,7 @@
             <h3>유부</h3>
             <small>#촉촉 #별미</small>
             <img
+              alt="유부"
               src="https://img-cf.kurly.com/shop/data/goodsview/20190129/gv40000042637_1.jpg"
             />
             <i class="fa-solid fa-heart"></i>
@@ -105,6 +112,7 @@
             <h3>푸주</h3>
             <small>#dobo #fuzu</small>
             <img
+              alt="푸주"
               src="https://product-image.kurly.com/product/image/c5c5f9e4-5ee3-4e2b-b36b-1aa5301d97d6.jpg"
             />
             <i class="fa-solid fa-heart"></i>
@@ -113,6 +121,7 @@
             <h3>치즈떡</h3>
             <small>#쫄깃쫄깃 #말랑말랑</small>
             <img
+              alt="치즈떡"
               src="https://img-cf.kurly.com/shop/data/goods/1640659336778l0.jpg"
             />
             <i class="fa-solid fa-heart"></i>
@@ -121,6 +130,7 @@
             <h3>새우</h3>
             <small>#무조건 #새우탕ㄱㄱ</small>
             <img
+              alt="새우"
               src="https://img-cf.kurly.com/shop/data/goodsview/20211227/gv20000262359_1.jpg"
             />
             <i class="fa-solid fa-heart"></i>

--- a/week1/assign3/index.html
+++ b/week1/assign3/index.html
@@ -17,8 +17,8 @@
       <button id="header__button"><i class="fa-solid fa-bars"></i></button>
       <section id="header__menu">
         <h1>메뉴</h1>
-        <h2>새 상품 추가</h2>
-        <h2>찜 목록</h2>
+        <h3>새 상품 추가</h3>
+        <h3>찜 목록</h3>
       </section>
     </header>
     <main>
@@ -51,7 +51,7 @@
             <img
               src="https://img-cf.kurly.com/shop/data/goods/1619680685239l0.jpg"
             />
-            <i class="fa-regular fa-heart"></i>
+            <i class="fa-solid fa-heart"></i>
           </li>
           <li class="cards__card">
             <h3>배추</h3>
@@ -59,7 +59,7 @@
             <img
               src="https://img-cf.kurly.com/shop/data/goodsview/20200717/gv00000107986_1.jpg"
             />
-            <i class="fa-regular fa-heart"></i>
+            <i class="fa-solid fa-heart"></i>
           </li>
           <li class="cards__card">
             <h3>연근</h3>
@@ -67,7 +67,7 @@
             <img
               src="https://img-cf.kurly.com/shop/data/goodsview/20220216/gv20000280932_1.jpg"
             />
-            <i class="fa-regular fa-heart"></i>
+            <i class="fa-solid fa-heart"></i>
           </li>
           <li class="cards__card">
             <h3>흰목이버섯</h3>
@@ -75,7 +75,7 @@
             <img
               src="https://img-cf.kurly.com/shop/data/goodsview/20200515/gv20000095604_1.jpg"
             />
-            <i class="fa-regular fa-heart"></i>
+            <i class="fa-solid fa-heart"></i>
           </li>
           <li class="cards__card">
             <h3>새송이버섯</h3>
@@ -83,7 +83,7 @@
             <img
               src="https://img-cf.kurly.com/shop/data/goodsview/20200306/gv20000084569_1.jpg"
             />
-            <i class="fa-regular fa-heart"></i>
+            <i class="fa-solid fa-heart"></i>
           </li>
           <li class="cards__card">
             <h3>면두부</h3>
@@ -91,7 +91,7 @@
             <img
               src="https://img-cf.kurly.com/shop/data/goodsview/20211110/gv30000241778_1.jpg"
             />
-            <i class="fa-regular fa-heart"></i>
+            <i class="fa-solid fa-heart"></i>
           </li>
           <li class="cards__card">
             <h3>유부</h3>
@@ -99,7 +99,7 @@
             <img
               src="https://img-cf.kurly.com/shop/data/goodsview/20190129/gv40000042637_1.jpg"
             />
-            <i class="fa-regular fa-heart"></i>
+            <i class="fa-solid fa-heart"></i>
           </li>
           <li class="cards__card">
             <h3>푸주</h3>
@@ -107,7 +107,7 @@
             <img
               src="https://product-image.kurly.com/product/image/c5c5f9e4-5ee3-4e2b-b36b-1aa5301d97d6.jpg"
             />
-            <i class="fa-regular fa-heart"></i>
+            <i class="fa-solid fa-heart"></i>
           </li>
           <li class="cards__card">
             <h3>치즈떡</h3>
@@ -115,7 +115,7 @@
             <img
               src="https://img-cf.kurly.com/shop/data/goods/1640659336778l0.jpg"
             />
-            <i class="fa-regular fa-heart"></i>
+            <i class="fa-solid fa-heart"></i>
           </li>
           <li class="cards__card">
             <h3>새우</h3>
@@ -123,7 +123,7 @@
             <img
               src="https://img-cf.kurly.com/shop/data/goodsview/20211227/gv20000262359_1.jpg"
             />
-            <i class="fa-regular fa-heart"></i>
+            <i class="fa-solid fa-heart"></i>
           </li>
         </ul>
       </section>

--- a/week1/assign3/style.css
+++ b/week1/assign3/style.css
@@ -344,9 +344,14 @@ img {
   color: var(--main-color);
 }
 
-.cards__card small {
+.cards__card__tags {
   width: 9rem;
-  white-space: nowrap;
+  height: 1rem;
   overflow: hidden;
+  word-break: keep-all;
   text-align: center;
+}
+
+.cards__card__tags > small::before {
+  content: "#";
 }

--- a/week1/assign3/style.css
+++ b/week1/assign3/style.css
@@ -150,14 +150,24 @@ table {
   font-style: normal;
 }
 
+@font-face {
+  font-family: "EBSHunminjeongeumSBA";
+  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_one@1.0/EBSHunminjeongeum.woff")
+    format("woff");
+  font-weight: normal;
+  font-style: normal;
+}
+
 body {
   font-family: "Pretendard-Regular", sans-serif;
 }
 
 h1 {
+  font-family: EBSHunminjeongeumSBA;
   font-size: 2rem;
 }
 h2 {
+  font-family: EBSHunminjeongeumSBA;
   font-size: 1.8rem;
 }
 h3 {
@@ -173,6 +183,7 @@ header {
   width: -webkit-fill-available;
   display: flex;
   justify-content: space-between;
+  align-items: center;
   position: fixed;
   background-color: var(--main-color);
   color: white;

--- a/week1/assign3/style.css
+++ b/week1/assign3/style.css
@@ -1,0 +1,125 @@
+/* reset.css */
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
+}
+body {
+  line-height: 1;
+}
+ol,
+ul {
+  list-style: none;
+}
+blockquote,
+q {
+  quotes: none;
+}
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
+}
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}

--- a/week1/assign3/style.css
+++ b/week1/assign3/style.css
@@ -87,6 +87,17 @@ video {
   font: inherit;
   vertical-align: baseline;
 }
+
+button {
+  background: inherit;
+  border: none;
+  box-shadow: none;
+  border-radius: 0;
+  padding: 0;
+  overflow: visible;
+  cursor: pointer;
+}
+
 /* HTML5 display-role reset for older browsers */
 article,
 aside,
@@ -122,4 +133,30 @@ q:after {
 table {
   border-collapse: collapse;
   border-spacing: 0;
+}
+
+/* font setting */
+@font-face {
+  font-family: "TAEBAEKmilkyway";
+  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2302@1.0/TAEBAEKmilkyway.woff2")
+    format("woff2");
+  font-weight: normal;
+  font-style: normal;
+}
+
+body {
+  font-family: "TAEBAEKmilkyway", sans-serif;
+}
+
+h1 {
+  font-size: 1.8rem;
+}
+h2 {
+  font-size: 1.3rem;
+}
+h3 {
+  font-size: 1rem;
+}
+small {
+  font-size: 0.5rem;
 }

--- a/week1/assign3/style.css
+++ b/week1/assign3/style.css
@@ -218,6 +218,47 @@ header {
   cursor: pointer;
 }
 
+/* nav */
+main {
+  padding-top: 8rem;
+  display: flex;
+}
+
+nav {
+  background-color: black;
+  color: white;
+  padding: 2rem;
+  margin-left: 2rem;
+  width: 10rem;
+  height: fit-content;
+  border-radius: 1rem;
+}
+
+nav h2 {
+  margin-bottom: 2rem;
+}
+
+nav li {
+  display: flex;
+  background-color: white;
+  color: var(--main-color);
+  padding: 1rem;
+  margin-bottom: 1rem;
+  border-radius: 1rem;
+}
+
+nav li:hover {
+  background-color: var(--main-color);
+  color: white;
+}
+
+nav h3 {
+  padding-left: 0.5rem;
+}
+nav li:last-child {
+  margin-bottom: 0;
+}
+
 img {
   width: 10rem;
 }

--- a/week1/assign3/style.css
+++ b/week1/assign3/style.css
@@ -1,4 +1,4 @@
-/* reset.css */
+/* basic setting */
 html,
 body,
 div,
@@ -114,6 +114,8 @@ section {
 }
 body {
   line-height: 1;
+  background-color: white;
+  color: black;
 }
 ol,
 ul {
@@ -135,17 +137,21 @@ table {
   border-spacing: 0;
 }
 
+:root {
+  --main-color: rgb(141, 19, 19); /* CSS 전역 변수 선언 */
+}
+
 /* font setting */
 @font-face {
-  font-family: "TAEBAEKmilkyway";
-  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2302@1.0/TAEBAEKmilkyway.woff2")
-    format("woff2");
-  font-weight: normal;
+  font-family: "Pretendard-Regular";
+  src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff")
+    format("woff");
+  font-weight: 400;
   font-style: normal;
 }
 
 body {
-  font-family: "TAEBAEKmilkyway", sans-serif;
+  font-family: "Pretendard-Regular", sans-serif;
 }
 
 h1 {
@@ -159,4 +165,59 @@ h3 {
 }
 small {
   font-size: 0.5rem;
+}
+
+/* header */
+header {
+  padding: 2rem;
+  width: -webkit-fill-available;
+  display: flex;
+  justify-content: space-between;
+  position: fixed;
+  background-color: var(--main-color);
+  color: white;
+}
+
+#header__menu {
+  display: none;
+}
+
+#header__button {
+  width: 2rem;
+  height: 2rem;
+}
+
+#header__button i {
+  color: white;
+  font-size: 1.2rem;
+}
+
+#header__button:hover + #header__menu,
+#header__menu:hover {
+  display: block;
+}
+
+#header__menu {
+  background-color: black;
+  color: white;
+  height: 100vh;
+  position: absolute;
+  right: 0;
+  top: 0;
+  padding: 2rem;
+  width: 10rem;
+}
+
+#header__menu > h1 {
+  padding-bottom: 2rem;
+  font-weight: bold;
+}
+
+#header__menu > h2 {
+  padding-bottom: 1rem;
+  cursor: pointer;
+}
+
+img {
+  width: 10rem;
 }

--- a/week1/assign3/style.css
+++ b/week1/assign3/style.css
@@ -213,9 +213,16 @@ header {
   font-weight: bold;
 }
 
-#header__menu > h2 {
-  padding-bottom: 1rem;
+#header__menu > h3 {
+  padding-bottom: 1.5rem;
   cursor: pointer;
+}
+
+#header__menu > h3:hover {
+  text-decoration-line: underline;
+  text-decoration-style: wavy;
+  text-decoration-color: var(--main-color);
+  text-underline-offset: 0.3rem;
 }
 
 /* nav */
@@ -324,4 +331,11 @@ img {
 
 .cards__card i:hover {
   color: var(--main-color);
+}
+
+.cards__card small {
+  width: 9rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-align: center;
 }

--- a/week1/assign3/style.css
+++ b/week1/assign3/style.css
@@ -155,16 +155,16 @@ body {
 }
 
 h1 {
-  font-size: 1.8rem;
+  font-size: 2rem;
 }
 h2 {
-  font-size: 1.3rem;
+  font-size: 1.8rem;
 }
 h3 {
-  font-size: 1rem;
+  font-size: 1.3rem;
 }
 small {
-  font-size: 0.5rem;
+  font-size: 0.8rem;
 }
 
 /* header */
@@ -263,8 +263,8 @@ nav li:last-child {
 
 /* cards */
 img {
-  width: 8rem;
-  height: 5rem;
+  width: 100%;
+  height: 8rem;
   object-fit: cover;
 }
 
@@ -317,4 +317,11 @@ img {
 
 .cards__card i {
   margin-bottom: 0;
+  align-self: flex-end;
+  padding-right: 0.5rem;
+  cursor: pointer;
+}
+
+.cards__card i:hover {
+  color: var(--main-color);
 }

--- a/week1/assign3/style.css
+++ b/week1/assign3/style.css
@@ -114,8 +114,8 @@ section {
 }
 body {
   line-height: 1;
-  background-color: white;
-  color: black;
+  background-color: black;
+  color: white;
 }
 ol,
 ul {
@@ -198,8 +198,8 @@ header {
 }
 
 #header__menu {
-  background-color: black;
-  color: white;
+  background-color: white;
+  color: black;
   height: 100vh;
   position: absolute;
   right: 0;
@@ -220,15 +220,17 @@ header {
 
 /* nav */
 main {
+  padding: 2rem;
   padding-top: 8rem;
-  display: flex;
+  display: grid;
+  grid-gap: 2rem;
+  grid-template-columns: 1fr 6fr;
 }
 
 nav {
-  background-color: black;
+  background-color: var(--main-color);
   color: white;
   padding: 2rem;
-  margin-left: 2rem;
   width: 10rem;
   height: fit-content;
   border-radius: 1rem;
@@ -248,7 +250,7 @@ nav li {
 }
 
 nav li:hover {
-  background-color: var(--main-color);
+  background-color: black;
   color: white;
 }
 
@@ -259,6 +261,60 @@ nav li:last-child {
   margin-bottom: 0;
 }
 
+/* cards */
 img {
-  width: 10rem;
+  width: 8rem;
+  height: 5rem;
+  object-fit: cover;
+}
+
+#cards ul {
+  display: grid;
+  grid-template-columns: repeat(5, 13rem);
+}
+
+@media screen and (max-width: 1330px) {
+  #cards ul {
+    grid-template-columns: repeat(4, 13rem);
+  }
+}
+
+@media screen and (max-width: 1120px) {
+  #cards ul {
+    grid-template-columns: repeat(3, 13rem);
+  }
+}
+
+@media screen and (max-width: 900px) {
+  #cards ul {
+    grid-template-columns: repeat(2, 13rem);
+  }
+}
+
+@media screen and (max-width: 690px) {
+  #cards ul {
+    grid-template-columns: repeat(1, 13rem);
+  }
+  #cards {
+    justify-self: center;
+  }
+}
+
+.cards__card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: white;
+  border-radius: 1rem;
+  color: black;
+  padding: 2rem 1rem;
+  margin: 0.5rem;
+}
+
+.cards__card > * {
+  margin-bottom: 1rem;
+}
+
+.cards__card i {
+  margin-bottom: 0;
 }


### PR DESCRIPTION
## <a href="https://simeunseo.github.io/sopt32/week1/assign3/index.html" target="_blank">🔗 구현 페이지</a>

## ✨ 구현 기능 명세

- ### 기본 과제
  - #### header
    - [x] 상표와 메뉴 아이콘을 space-between으로 정렬
    - [x] position:fixed로 상단 고정
  - #### nav
    - [x] 제목과 4개의 카테고리로 구성
  - #### nav와 card section 배치
    - [x] grid로 nav와 cards를 두 개의 column으로 배치
  - #### card section
    - [x] card section 내 cards또한 grid로 배치
    - [x] 상품 제목, 해시태그, 이미지, 하트찜 구현 및 가운데 정렬
    - [x] 하트찜은 align-self: flex-end로 오른쪽정렬
    - [x] 해시태그 글자수가 특정 width(9rem)를 넘어가면 보이지 않도록 처리
- ### 심화 과제
  - #### hover
    - [x] 메뉴 아이콘 hover시 메뉴바 나타남
    - [x] 10rem으로 width 고정, height는 100vh
    - [x] nav 카테고리에 hover시 배경과 글자색 변경
  - #### 반응형 레이아웃
    - [x] media query로 특정 분기점에 따라 grid의 column개수를 5->4->3->2->1로 변경
    - [x] 마지막 한 줄 정렬시에는 card section을 nav를 제외한 영역에서 가운데 정렬
    - [x] header, nav는 align-items:center로 세로 정렬

<br />

## 🌼 PR Point

- #### 시맨틱 코드
  평소 남발하던 div와 p태그를 한번도 쓰지 않아보았습니다!
  [https://inpa.tistory.com/entry/HTML-🏷️-태그-요약표](https://inpa.tistory.com/entry/HTML-%F0%9F%8F%B7%EF%B8%8F-%ED%83%9C%EA%B7%B8-%EC%9A%94%EC%95%BD%ED%91%9C)
  이 자료에 많은 태그들이 정리되어 있어서 참고하기 좋았습니다~
- #### 메뉴 아이콘 hover시 메뉴바가 나타나도록 하기
  display:none으로 되어있던 메뉴바를 메뉴 아이콘 hover시에 display:block으로 바꿨습니다. 그런데 메뉴바가 화면에 나타나면 메뉴바가 메뉴 아이콘을 가리기 때문에, 더이상 메뉴아이콘을 hover하지 않은 상태가 되어 메뉴가 제대로 나타나지 않았습니다. 따라서 '메뉴 바'에 마우스가 hover되어있을 때도 display:block이 되도록 하는 코드를 추가하여 해결했습니다! 현수랑 보미는 어떻게 구현했을지 궁금하네용...
  ```css
  #header__menu {
    display: none;
  }

  #header__button:hover + #header__menu,
  #header__menu:hover {
    display: block;
  }
  ```
- #### 넘치는 해시태그 숨기기
  해시태그 영역에 9rem으로 width를 정해주고, white-space:nowrap으로 하여 글자가 너비를 넘어가도 줄바꿈이 되지 않도록 했습니다. 그러면 width를 넘어가는 부분이 숨겨지게 해야했는데, overflow: hidden을 통해 구현 가능했습니다!

  _➕ (0407 수정사항 1)_
  정찬우님🙏 코드에서 해시태그 앞에 '#'을 붙일 때 하드코딩이 아니라 before라는 가상 클래스 선택자를 사용하신 걸 보고 훨씬 스마트한 방법인 것 같아서 저도 변경해보았습니다! {선택자}::before는 해당 요소의 앞을 가리키는 선택자이며, ::after는 해당 요소의 뒤를 선택할 수 있습니다.
  ```css
  .cards__card__tags > small::before {
    content: "#";
  }
  ```
  _➕ (0407 수정사항 2)_
  마찬가지로 정찬우님🙏 코드를 참고해서, 넘치는 부분이 중간에 그냥 잘리는 게 아니라 단어 단위로 잘릴 수 있도록 수정했습니다! 
  해시태그들을 하나의 div로 묶고, 여기에 다음과 같은 css를 추가했습니다.
  ```css
  .cards__card__tags {
    width: 9rem;
    height: 1rem;  /*new*/
    overflow: hidden;
    word-break: keep-all; /*new*/
    text-align: center;
  }
  ```
  word-break:keep-all로 글자가 width를 넘어갈 시에 단어 단위로 줄바꿈이 되도록 하고, 두번째 줄로 넘어간 글자는 보이지 않도록 height를 주었습니다.

  이 줄바꿈 속성은 언어에 따라 다르게 적용되는데, 한글단어의 경우 앞의 #와 다른 단어로 취급되어 아래와같이 #는 윗 줄에 남아있게 됩니다.
  <img width="505" alt="한글줄바꿈" src="https://user-images.githubusercontent.com/55528304/230549381-6d46f37e-0e3a-49f3-8482-2bf94e631a77.png">
  그러나 영어의 경우 #와 붙어서 함께 줄바꿈이 되는 것을 알 수 있었습니다!
  <img width="505" alt="영어줄바꿈" src="https://user-images.githubusercontent.com/55528304/230549507-ad61ca88-ca58-4a05-bce0-f147b0f2e7cb.png">

  [줄바꿈 속성 참고자료](https://www.codingfactory.net/10658)

- #### card 한 줄 정렬시 가운데 정렬
  card section 안의 card들을 grid로 배치하고, nav와 card section또한 두 개의 column으로 이루어진 grid로 배치했습니다. 따라서 card section이 한 줄 정렬이 됐을 때 이 영억을 단독적으로 가운데 정렬할 수 있었습니다.
  <img width="505" alt="cards의 배치" src="https://user-images.githubusercontent.com/55528304/230550897-a1fcddfa-2ed7-4d41-a6d3-ba32003042bd.png">
  화면의 width에 따라 한 행에 위치하는 frame의 개수가 달라집니다. (5->4->3->2->1)
  <img width="505" alt="nav와 cards의 배치" src="https://user-images.githubusercontent.com/55528304/230551098-f9e167f2-c798-4e73-83da-948d040dea57.png">
  ```css
  @media screen and (max-width: 690px) {
    #cards ul {
      grid-template-columns: repeat(1, 13rem);
    }
    #cards {
      justify-self: center;
    }
  }
  ```



<br />

## 🥺 소요 시간, 어려웠던 점

- `3h`
- 처음에 grid를 안쓰고 display:flex로만 정렬을 하려고 시도했는데, 그렇게 했더니 card section이 한 줄 정렬 됐을 때 가운데로 배치하는걸 어떻게 해야할 지 모르겠더라구요..! nav와 card section을 따로 나눠서 정렬하는게 필요했는데... 뭔가 복잡해져서 grid로 전부 바꿨습니다. flex로 구현한 분들은 어떻게 했는지 궁금!!

<br />

## 🌈 구현 결과물

- #### 전체 화면

<img width="1552" alt="전체 화면" src="https://user-images.githubusercontent.com/55528304/229406158-5fd41877-2a61-41b1-9b4f-bb6e0e89b1a5.png">

- #### hover

<img width="1552" alt="hover" src="https://user-images.githubusercontent.com/55528304/229435092-7aa2a5a7-b088-4c7e-a089-8a6243141b8a.gif">

- #### 반응형

<img width="1552" alt="반응형" src="https://user-images.githubusercontent.com/55528304/229409725-20829685-ba54-4f68-a960-3bd169f2d744.gif">

- #### 해시태그 영역에 긴 텍스트가 들어가도 9rem을 넘어가면 나타나지 않는 모습
<img width="1552" alt="해시태그 영역에 긴 텍스트가 들어가도 9rem을 넘어가면 나타나지 않는 모습" src="https://user-images.githubusercontent.com/55528304/229408950-cd0e40d5-b5b5-423c-b775-4d1b95f15790.gif">
